### PR TITLE
Event Card button Css fix complete

### DIFF
--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -19,7 +19,7 @@ const EventCard: FC<TEvent> = ({ title, cover, description, id }) => {
         <div className="h-full max-h-[200px] overflow-hidden w-full">
           <Image
             src={cover}
-            alt=""
+            alt="Event cover image"
             className="aspect-square w-full"
             width={300}
             height={300}
@@ -27,14 +27,16 @@ const EventCard: FC<TEvent> = ({ title, cover, description, id }) => {
           />
         </div>
       </CardHeader>
-      <CardContent className="pt-3 bg-inherit h-full">
-        <CardTitle className="text-2xl font-medium line-clamp-2">
-          {title}
-        </CardTitle>
-        <CardDescription className="mt-2">
-          <p className="line-clamp-3">{description}</p>
-        </CardDescription>
-        <Link href={`/events/${id}`} className="justify-self-end">
+      <CardContent className="pt-3 bg-inherit h-full flex flex-col">
+        <div className="flex-grow">
+          <CardTitle className="text-2xl font-medium line-clamp-2">
+            {title}
+          </CardTitle>
+          <CardDescription className="mt-2">
+            <p className="line-clamp-3">{description}</p>
+          </CardDescription>
+        </div>
+        <Link href={`/events/${id}`} className="mt-auto">
           <Button className="w-full mt-3">
             View Event <ChevronRight className="size-5 ml-2 opacity-80" />
           </Button>
@@ -43,4 +45,5 @@ const EventCard: FC<TEvent> = ({ title, cover, description, id }) => {
     </Card>
   );
 };
+
 export default EventCard;


### PR DESCRIPTION
# Fix Overview 

![image](https://github.com/user-attachments/assets/3a73e010-1841-4f90-9361-de5f32a2e904)


This fix ensures that the buttons are aligned consistently at the bottom of each event card. 

### Changes Made:
1. **Flexbox Usage:**
   - Added `flex-grow` to the content wrapper to ensure the description area grows to take up available space.
   - Added `mt-auto` to the button container to push the button to the bottom of the card.

2. **Link/Button Alignment:**
   - Ensured the button container adopts proper `w-full` and margin classes for spacing and alignment.

### Code Snippet:

```jsx
<CardContent className="pt-3 bg-inherit h-full flex flex-col">
    <div className="flex-grow">
        <CardTitle className="text-2xl font-medium line-clamp-2">
            {title}
        </CardTitle>
        <CardDescription className="mt-2">
            <p className="line-clamp-3">{description}</p>
        </CardDescription>
    </div>
    <Link href={`/events/${id}`} className="mt-auto">
        <Button className="w-full mt-3">
            View Event <ChevronRight className="size-5 ml-2 opacity-80" />
        </Button>
    </Link>
</CardContent>
```

### After Fix:
- The buttons are now consistently aligned at the bottom of each card, regardless of card content height, ensuring a clean and uniform UI.