### PR TITLE
Issue #24 [FEATURE] To Add Top 3 Events on Home Page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { BenefitsSection } from "@/components/layout/sections/About";
 import { CommunitySection } from "@/components/layout/sections/Community";
+import Events from "@/components/layout/sections/Events";
 import { FAQSection } from "@/components/layout/sections/Faq";
 import { FooterSection } from "@/components/layout/sections/Footer";
 import { HeroSection } from "@/components/layout/sections/Hero";
@@ -7,21 +8,24 @@ import { SponsorsSection } from "@/components/layout/sections/Sponsors";
 import { TeamSection } from "@/components/layout/sections/Team";
 import { TestimonialSection } from "@/components/layout/sections/Testimonial";
 import { TextHoverEffectSection } from "@/components/layout/sections/TextHoverEffectSection";
+import { getSortedPostsData } from "@/lib/utils";
 
 export const metadata = {
   title: "MU-ACM",
   description: "MU-ACM - Medicaps University ACM Student Chapter",
   icons: {
-    icon: "/logo.png", 
+    icon: "/logo.png",
   },
 };
 
 export default function Home() {
+  const data = getSortedPostsData();
   return (
     <>
       <HeroSection />
       <SponsorsSection />
       <BenefitsSection />
+      <Events data={data} />
       <TeamSection />
       <TestimonialSection />
       <CommunitySection />

--- a/src/components/layout/sections/Events.tsx
+++ b/src/components/layout/sections/Events.tsx
@@ -1,6 +1,7 @@
 "use client";
 import EventCard from "@/components/event-card";
 import { TEvent } from "@/lib/types";
+import { usePathname } from "next/navigation";
 import { FC } from "react";
 
 type EventsProps = {
@@ -8,17 +9,26 @@ type EventsProps = {
 };
 
 const Events: FC<EventsProps> = ({ data }) => {
+  const pathname = usePathname();
+  const latestEventsData = data?.slice(0, 3);
   return (
     <section className="container w-full mt-[80px] pb-24">
       <div className="text-center mb-8">
+        {pathname && pathname === "/" ? (
+          <h2 className="text-lg text-primary text-center mb-2 tracking-wider">
+            Upcoming & Latest Events
+          </h2>
+        ) : null}
         <h2 className="text-3xl md:text-4xl text-center font-bold">
-          Our Amazing Events
+          {pathname === "/" ? "Our Amazing Events" : "Our Amazing Events"}
         </h2>
       </div>
-      <div className=" grid  md:grid-cols-2 lg:grid-cols-3 mt-10 gap-6">
-        {data?.map((event) => (
-          <EventCard key={event.id} {...event} />
-        ))}
+      <div className="grid  md:grid-cols-2 lg:grid-cols-3 mt-10 gap-6">
+        {pathname === "/"
+          ? latestEventsData?.map((event) => (
+              <EventCard key={event.id} {...event} />
+            ))
+          : data?.map((event) => <EventCard key={event.id} {...event} />)}
       </div>
     </section>
   );

--- a/src/components/layout/sections/Sponsors.tsx
+++ b/src/components/layout/sections/Sponsors.tsx
@@ -38,7 +38,7 @@ export const SponsorsSection = () => {
   return (
     <section id="sponsors" className="max-w-[75%] mx-auto pb-24 sm:pb-32">
       <h2 className="text-lg md:text-3xl text-center mb-6 font-bold">
-        Our Amazing Events
+        Our Past Events
       </h2>
 
       <div className="mx-auto">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,11 +55,7 @@ export function getSortedPostsData() {
     } as TEvent;
   });
   // Sort posts by date
-  return allPostsData.sort((a, b) => {
-    if (new Date(a.date) < new Date(b.date)) {
-      return 1;
-    } else {
-      return -1;
-    }
-  });
+  return allPostsData.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
 }


### PR DESCRIPTION
This PR closes #24 

## Code Fixes:
- Changed the heading of marquee section as it was creating ambiguity on home page
- Used usePathName() hook of nextjs to configure Events component to be used on homepage and events page both.
- Updated getSortedPostsData() sorting in utils that makes it more easier to compare dates.

**NOTE:** I have checked the impact of my code changes & also by running build command, and everything seems fine. So, this PR could be merged.

@Ashpara10 @ramxcodes please add hacktoberfest-accepted label to this PR.

Thanks & Regards,
Atharv Vani